### PR TITLE
Version 1.1.2

### DIFF
--- a/src/billmate-order-management-for-woocommerce.php
+++ b/src/billmate-order-management-for-woocommerce.php
@@ -12,7 +12,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 4.0.0
- * WC tested up to: 5.0.0
+ * WC tested up to: 5.1.0
  *
  * Copyright:       © 2020-2021 Billmate in collaboration with Krokedil.
  * License:         GNU General Public License v3.0
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'BILLMATE_ORDER_MANAGEMENT_VERSION', '1.1.1' );
+define( 'BILLMATE_ORDER_MANAGEMENT_VERSION', '1.1.2' );
 define( 'BILLMATE_ORDER_MANAGEMENT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'BILLMATE_ORDER_MANAGEMENT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'BILLMATE_ORDER_MANAGEMENT_ENV', 'https://api.billmate.se' );

--- a/src/classes/class-bom-order-management.php
+++ b/src/classes/class-bom-order-management.php
@@ -112,9 +112,9 @@ class BOM_Order_Management {
 		}
 
 		// Don't try to activate direct payment method orders.
-		// 16=Bank, 24=Card/Bank, 32=Cash (Receipt).
+		// 16=Bank, 24=Card/Bank, 32=Cash (Receipt), 1024=Swish.
 		// Only check this for bco payment method. Not the old billmate_checkout.
-		if ( 'bco' === $order->get_payment_method() && in_array( get_post_meta( $order_id, '_billmate_payment_method_id', true ), array( '16', '24', '32' ), true ) ) {
+		if ( 'bco' === $order->get_payment_method() && in_array( get_post_meta( $order_id, '_billmate_payment_method_id', true ), array( '16', '24', '32', '1024' ), true ) ) {
 			return;
 		}
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,10 +2,10 @@
 Contributors: Billmate, Krokedil, NiklasHogefjord
 Tags: woocommerce, billmate, ecommerce, e-commerce, checkout, swish, invoice, part-payment, partpayment, card, mastercard, visa, trustly
 Requires at least: 5.0
-Tested up to: 5.6.1
+Tested up to: 5.7
 Requires PHP: 5.6
 WC requires at least: 4.0.0
-WC tested up to: 5.0.0
+WC tested up to: 5.1.0
 Stable tag: __STABLE_TAG__
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -41,6 +41,9 @@ We have a portal for users to provide feedback, [https://woocommerce.portal.bill
 The easiest way to report a bug is to email us at [support@billmate.se](mailto:support@billmate.se). If you however are a developer you can feel free to raise an issue on GitHub, [https://github.com/Billmate/billmate-order-mangement-for-woocommerce](https://github.com/Billmate/billmate-order-mangement-for-woocommerce).
 
 == Changelog ==
+= 2021.04.07    - version 1.1.2 =
+* Fix           - Don't try to activate orders with Swish as payment method.
+
 = 2021.02.16    - version 1.1.1 =
 * Fix           - Add support for refunding (credit) part payment orders.
 


### PR DESCRIPTION
* Fix - Don't try to activate orders with Swish as payment method.